### PR TITLE
Bug/#6 skill dividers

### DIFF
--- a/src/components/ExperienceComponent.vue
+++ b/src/components/ExperienceComponent.vue
@@ -89,9 +89,9 @@ export default {
     &__line
       content: ' '
       margin-left: 6px
-      background: rgba(0, 0, 0, .5)
+      border-bottom: 2px solid rgba(0, 0, 0, .5)
       flex-grow: 1
-      height: 2px
+      height: max-content
   .list
     font-size: 1.2rem
 </style>

--- a/src/components/ExperienceComponent.vue
+++ b/src/components/ExperienceComponent.vue
@@ -89,9 +89,9 @@ export default {
     &__line
       content: ' '
       margin-left: 6px
-      border: 1px solid rgba(0, 0, 0, .5)
+      background: rgba(0, 0, 0, .5)
       flex-grow: 1
-      height: max-content
+      height: 2px
   .list
     font-size: 1.2rem
 </style>


### PR DESCRIPTION
- use border bottom instead, because the height of the elements seem to vary